### PR TITLE
Avoid spreading the GFF tibble

### DIFF
--- a/bin/padloc.R
+++ b/bin/padloc.R
@@ -203,8 +203,9 @@ separate_attributes <- function(gff) {
     separate_rows(attributes, sep = ";") %>%
     filter(attributes != "") %>%
     separate(attributes, into = c("key", "value"), sep = "=") %>% 
-    spread(key = key, value = value, fill = NA)
-  
+    filter(key == "ID") %>%
+    select(-source, -phase, -key) %>%
+    rename(ID = value)  
 }
 
 # gather_attributes(gff)


### PR DESCRIPTION
When dealing with a large GFF, the spread operation can take a long time and storing all the attributes in memory can be costly. To avoid using `spread`, I select only the rows where `key == ID` (as this is the only attribute that will be used downstream). I'm also removing other unused columns to reduce memory usage.